### PR TITLE
Add attn residuals with mHC (but use conv layer), then mHC with gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ config = BiBoConfig(
     residual_mixer_type="dynamic_causal_conv",  # "none", "causal_conv", or "dynamic_causal_conv"
     residual_conv_kernel_size=4,
     residual_conv_init=0.95,
+    residual_history_include_input=False,       # Keep depth history to layer outputs by default
 
     # mHC-style parallel residual streams
     residual_num_streams=2,             # 1 disables multi-stream residuals
+    residual_stream_mode="delay_line",  # "independent" or "delay_line"
     residual_stream_gate_type="token",  # "scalar" or "token"
     residual_stream_init="copy",        # "copy" or "zero"
     residual_stream_read_init=0.99,
@@ -173,6 +175,13 @@ Residual gates keep the identity path intact and only scale the branch write:
 ```python
 x = residual + gate * branch_output
 ```
+
+For a clean mHC-style run, keep `residual_gate_type="none"` and use
+`residual_num_streams > 1`; enabling both is supported, but branch gates and
+stream write gates compose and should be logged as a combined experiment.
+Set `residual_stream_mode="delay_line"` to make stream index causal over depth:
+stream 0 is newest, stream 1 is one layer old, and each layer performs a learned
+read followed by a deterministic shift write.
 
 After a forward pass, inspect flow statistics:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **SSMax attention**: Learnable per-head scaling for long context
 - **Sliding window attention**: Optional local attention windows
 - **RoPE**: Rotary position embeddings with configurable base
+- **Residual write gates**: Optional mHC-inspired gates for attention and MLP/MoE residual updates
 
 ### Training Features
 
@@ -144,11 +145,46 @@ config = BiBoConfig(
     use_sliding_window=True,
     sliding_window=512,
     max_window_layers=4,
+
+    # Residual flow gates
+    residual_gate_type="token",  # "none", "scalar", "token", or "channel"
+    residual_gate_init=0.95,     # Start close to standard residual behavior
+
+    # Causal residual-state mixer over model depth
+    residual_mixer_type="dynamic_causal_conv",  # "none", "causal_conv", or "dynamic_causal_conv"
+    residual_conv_kernel_size=4,
+    residual_conv_init=0.95,
+
+    # mHC-style parallel residual streams
+    residual_num_streams=2,             # 1 disables multi-stream residuals
+    residual_stream_gate_type="token",  # "scalar" or "token"
+    residual_stream_init="copy",        # "copy" or "zero"
+    residual_stream_read_init=0.99,
+    residual_stream_write_init=0.99,
     
     # Position embeddings
     max_position_embeddings=32768,
     rope_theta=10000.0,
 )
+```
+
+Residual gates keep the identity path intact and only scale the branch write:
+
+```python
+x = residual + gate * branch_output
+```
+
+After a forward pass, inspect flow statistics:
+
+```python
+stats = model.model.residual_gate_stats()
+print(stats["layer_0/attn/mean"], stats["layer_0/mlp/mean"])
+
+depth_stats = model.model.residual_mixer_stats()
+print(depth_stats["layer_1/residual_conv/current_weight"])
+
+stream_stats = model.model.residual_stream_stats()
+print(stream_stats["layer_0/streams/read_main"])
 ```
 
 ## Testing

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -208,6 +208,136 @@ self.gate_conv = nn.Conv1d(config.hidden_size, self.num_routed_experts,
 
 ---
 
+### `residual_gate_type`
+
+**Default:** `"none"`
+
+**Options:** `"none"`, `"scalar"`, `"token"`, `"channel"`
+
+**What it does:**
+Adds optional mHC-inspired write gates around the attention and MLP/MoE residual branches:
+
+```python
+hidden_states = residual + gate * branch_output
+```
+
+The identity stream is never gated, so the model can always preserve normal residual flow.
+
+**Gate shapes:**
+- **none:** Standard residual add
+- **scalar:** One learned value per branch/layer
+- **token:** One value per token, shape `[batch, seq, 1]`
+- **channel:** One value per token/channel, shape `[batch, seq, hidden_size]`
+
+**Tuning guidance:**
+- Start with `"token"` for residual-flow diagnostics.
+- Use `"scalar"` for a very cheap stability experiment.
+- Use `"channel"` only if you can afford extra parameters and want more expressive control.
+
+### `residual_gate_init`
+
+**Default:** `0.95`
+
+Initial gate value. Values close to `1.0` preserve baseline Transformer behavior at initialization.
+The gate modules expose `mean`, `open_frac`, and `closed_frac` through:
+
+```python
+model.model.residual_gate_stats()
+```
+
+---
+
+### `residual_mixer_type`
+
+**Default:** `"none"`
+
+**Options:** `"none"`, `"causal_conv"`, `"dynamic_causal_conv"`
+
+**What it does:**
+Adds an attention-residual-style mixer over residual states from previous model depths.
+The `"causal_conv"` option replaces softmax attention over all previous layers with a
+small fully causal depth convolution:
+
+```python
+current = layer(hidden_states)
+hidden_states = causal_depth_conv(previous_states + [current])
+```
+
+This convolution is over **layer depth**, not over sequence tokens. It can only read
+previous residual states and the current layer output, so token-level causality is
+preserved. `"causal_conv"` uses one learned depth kernel per layer. `"dynamic_causal_conv"`
+uses the current token state to produce token-conditioned depth kernels.
+
+### `residual_conv_kernel_size`
+
+**Default:** `4`
+
+Number of depth states in the causal residual convolution window. The model keeps
+`kernel_size - 1` previous residual states plus the current layer output.
+
+### `residual_conv_init`
+
+**Default:** `0.95`
+
+Initial weight on the current layer output. The remaining mass is distributed across
+older residual states, keeping initialization close to normal Transformer flow.
+The mixer exposes `current_weight`, `previous_mass`, and `num_states` through:
+
+```python
+model.model.residual_mixer_stats()
+```
+
+---
+
+### `residual_num_streams`
+
+**Default:** `1`
+
+Number of mHC-style parallel residual streams. `1` disables multi-stream residuals.
+When enabled, each layer reads a gated mixture of streams, runs the normal decoder
+layer, then writes that layer's update back into the streams.
+
+```python
+read_state = gated_read(streams)
+layer_output = decoder_layer(read_state)
+streams = gated_write(streams, layer_output - read_state)
+```
+
+### `residual_stream_gate_type`
+
+**Default:** `"token"`
+
+**Options:** `"scalar"`, `"token"`
+
+- **scalar:** One read/write gate per layer and stream.
+- **token:** Per-token read/write gates over streams.
+
+### `residual_stream_init`
+
+**Default:** `"copy"`
+
+**Options:** `"copy"`, `"zero"`
+
+- **copy:** Every stream starts from the embedding state. This preserves the first
+  layer read even when the initial read gate is not exactly one-hot.
+- **zero:** Stream 0 starts from embeddings and auxiliary streams start at zero.
+
+### `residual_stream_read_init` / `residual_stream_write_init`
+
+**Default:** `0.99`
+
+Initial read mass and write gate value for stream 0. The remaining read mass is
+spread across auxiliary streams. These should stay close to `1.0` for baseline-like
+initialization.
+
+Inspect stream routing after a forward pass:
+
+```python
+model.model.residual_stream_stats()
+```
+
+---
+
 ## MoE Architecture
 
 ### `bias_update_threshold`

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -260,7 +260,7 @@ small fully causal depth convolution:
 
 ```python
 current = layer(hidden_states)
-hidden_states = causal_depth_conv(previous_states + [current])
+hidden_states = causal_depth_conv(previous_layer_states + [current])
 ```
 
 This convolution is over **layer depth**, not over sequence tokens. It can only read
@@ -287,6 +287,15 @@ The mixer exposes `current_weight`, `previous_mass`, and `num_states` through:
 model.model.residual_mixer_stats()
 ```
 
+### `residual_history_include_input`
+
+**Default:** `False`
+
+Whether to seed the depth residual history with the embedding output before layer 0.
+By default the mixer history contains only decoder layer outputs, so layer 0 sees only
+its own current output. Set this to `True` if you explicitly want the embedding state
+to be part of the early residual-depth window.
+
 ---
 
 ### `residual_num_streams`
@@ -302,6 +311,36 @@ read_state = gated_read(streams)
 layer_output = decoder_layer(read_state)
 streams = gated_write(streams, layer_output - read_state)
 ```
+
+The model performs one stream read before each layer and one final read after the
+last write for the output state. It does not re-read after every intermediate write.
+
+For cleaner attribution, use `residual_gate_type="none"` when experimenting with
+multi-stream residuals. Enabling branch residual gates and stream gates together is
+valid, but their effective scaling composes.
+
+### `residual_stream_mode`
+
+**Default:** `"independent"`
+
+**Options:** `"independent"`, `"delay_line"`
+
+- **independent:** Free mHC-style streams. Each layer writes its update into all
+  streams through learned write gates.
+- **delay_line:** Stream index is a causal depth axis. Stream 0 stores the newest
+  layer state, stream 1 stores the previous layer state, and so on. Reads are
+  learned, but writes are deterministic shifts:
+
+```python
+read_state = gated_read([x_t, x_t_minus_1, x_t_minus_2])
+new_state = decoder_layer(read_state)
+streams = [new_state, x_t, x_t_minus_1]
+```
+
+In delay-line mode, auxiliary streams start at zero regardless of
+`residual_stream_init`, because there is no older layer state at layer 0.
+This is the cleanest setting when you want the stream gate to act as a learned
+causal depth kernel.
 
 ### `residual_stream_gate_type`
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,6 +7,9 @@ from .modeling import (
     BiBoAttention,
     BiBoMLP,
     BiBoMoELayer,
+    BiBoResidualGate,
+    BiBoCausalResidualConv,
+    BiBoMultiStreamResidual,
     BiBoRMSNorm,
 )
 
@@ -18,5 +21,8 @@ __all__ = [
     'BiBoAttention',
     'BiBoMLP',
     'BiBoMoELayer',
+    'BiBoResidualGate',
+    'BiBoCausalResidualConv',
+    'BiBoMultiStreamResidual',
     'BiBoRMSNorm',
 ]

--- a/src/configuration_bibo.py
+++ b/src/configuration_bibo.py
@@ -70,7 +70,9 @@ class BiBoConfig(PretrainedConfig):
         residual_mixer_type="none", # none, causal_conv, or dynamic_causal_conv
         residual_conv_kernel_size=4, # Depth-causal residual states: previous kernel_size-1 + current
         residual_conv_init=0.95, # Initial weight on the current layer output
+        residual_history_include_input=False, # Include embeddings as the first depth residual state
         residual_num_streams=1, # mHC-style parallel residual streams; 1 disables
+        residual_stream_mode="independent", # independent or delay_line
         residual_stream_gate_type="token", # scalar or token
         residual_stream_init="copy", # copy or zero
         residual_stream_read_init=0.99, # Initial read mass on stream 0
@@ -129,7 +131,9 @@ class BiBoConfig(PretrainedConfig):
         self.residual_mixer_type = residual_mixer_type
         self.residual_conv_kernel_size = residual_conv_kernel_size
         self.residual_conv_init = residual_conv_init
+        self.residual_history_include_input = residual_history_include_input
         self.residual_num_streams = residual_num_streams
+        self.residual_stream_mode = residual_stream_mode
         self.residual_stream_gate_type = residual_stream_gate_type
         self.residual_stream_init = residual_stream_init
         self.residual_stream_read_init = residual_stream_read_init
@@ -236,8 +240,12 @@ class BiBoConfig(PretrainedConfig):
             raise ValueError("residual_conv_kernel_size must be greater than 1")
         if not (0.0 < self.residual_conv_init < 1.0):
             raise ValueError("residual_conv_init must be between 0 and 1")
+        if not isinstance(self.residual_history_include_input, bool):
+            raise ValueError("residual_history_include_input must be a boolean")
         if self.residual_num_streams < 1:
             raise ValueError("residual_num_streams must be at least 1")
+        if self.residual_stream_mode not in {"independent", "delay_line"}:
+            raise ValueError("residual_stream_mode must be one of: 'independent', 'delay_line'")
         if self.residual_stream_gate_type not in {"scalar", "token"}:
             raise ValueError("residual_stream_gate_type must be one of: 'scalar', 'token'")
         if self.residual_stream_init not in {"copy", "zero"}:
@@ -246,6 +254,16 @@ class BiBoConfig(PretrainedConfig):
             raise ValueError("residual_stream_read_init must be between 0 and 1")
         if not (0.0 < self.residual_stream_write_init < 1.0):
             raise ValueError("residual_stream_write_init must be between 0 and 1")
+        if (
+            self.residual_num_streams > 1
+            and self.residual_stream_mode == "independent"
+            and self.residual_gate_type != "none"
+        ):
+            logger.warning_once(
+                "Both residual branch gates and multi-stream write gates are enabled. "
+                "This is valid, but their effects compose; use residual_gate_type='none' "
+                "for cleaner mHC-style stream-gate attribution."
+            )
         for idx in self.mlp_only_layers:
             if not (0 <= idx < self.num_hidden_layers):
                 raise ValueError(f"mlp_only_layers index {idx} is out of range for {self.num_hidden_layers} layers")

--- a/src/configuration_bibo.py
+++ b/src/configuration_bibo.py
@@ -65,6 +65,16 @@ class BiBoConfig(PretrainedConfig):
         kernel_size=3,
         router_lambda=1.0, # Scaling for router logits before softmax (see Skywork-MoE paper, eq. 6)
         moe_shared_scaling=1.0, # Scaling for shared expert output in MoE block (see DeepSeek-V2/V3, Muon)
+        residual_gate_type="none", # none, scalar, token, or channel
+        residual_gate_init=0.95, # Initial residual write strength; 0.95 keeps baseline behavior
+        residual_mixer_type="none", # none, causal_conv, or dynamic_causal_conv
+        residual_conv_kernel_size=4, # Depth-causal residual states: previous kernel_size-1 + current
+        residual_conv_init=0.95, # Initial weight on the current layer output
+        residual_num_streams=1, # mHC-style parallel residual streams; 1 disables
+        residual_stream_gate_type="token", # scalar or token
+        residual_stream_init="copy", # copy or zero
+        residual_stream_read_init=0.99, # Initial read mass on stream 0
+        residual_stream_write_init=0.99, # Initial write gate on stream 0
 
         norm_topk_prob=False,
         output_router_logits=False,
@@ -114,6 +124,16 @@ class BiBoConfig(PretrainedConfig):
         self.norm_topk_prob = norm_topk_prob
         self.output_router_logits = output_router_logits
         self.router_lambda = router_lambda
+        self.residual_gate_type = residual_gate_type
+        self.residual_gate_init = residual_gate_init
+        self.residual_mixer_type = residual_mixer_type
+        self.residual_conv_kernel_size = residual_conv_kernel_size
+        self.residual_conv_init = residual_conv_init
+        self.residual_num_streams = residual_num_streams
+        self.residual_stream_gate_type = residual_stream_gate_type
+        self.residual_stream_init = residual_stream_init
+        self.residual_stream_read_init = residual_stream_read_init
+        self.residual_stream_write_init = residual_stream_write_init
 
         # --- Auto-estimate scaling factor for shared expert if left as 1.0 ---
         self.moe_shared_scaling = moe_shared_scaling
@@ -206,6 +226,26 @@ class BiBoConfig(PretrainedConfig):
             raise ValueError("router_noise must be non-negative")
         if self.num_experts_per_tok > self.num_experts:
             raise ValueError("num_experts_per_tok cannot exceed total number of experts")
+        if self.residual_gate_type not in {"none", "scalar", "token", "channel"}:
+            raise ValueError("residual_gate_type must be one of: 'none', 'scalar', 'token', 'channel'")
+        if not (0.0 < self.residual_gate_init < 1.0):
+            raise ValueError("residual_gate_init must be between 0 and 1")
+        if self.residual_mixer_type not in {"none", "causal_conv", "dynamic_causal_conv"}:
+            raise ValueError("residual_mixer_type must be one of: 'none', 'causal_conv', 'dynamic_causal_conv'")
+        if self.residual_conv_kernel_size <= 1:
+            raise ValueError("residual_conv_kernel_size must be greater than 1")
+        if not (0.0 < self.residual_conv_init < 1.0):
+            raise ValueError("residual_conv_init must be between 0 and 1")
+        if self.residual_num_streams < 1:
+            raise ValueError("residual_num_streams must be at least 1")
+        if self.residual_stream_gate_type not in {"scalar", "token"}:
+            raise ValueError("residual_stream_gate_type must be one of: 'scalar', 'token'")
+        if self.residual_stream_init not in {"copy", "zero"}:
+            raise ValueError("residual_stream_init must be one of: 'copy', 'zero'")
+        if not (0.0 < self.residual_stream_read_init < 1.0):
+            raise ValueError("residual_stream_read_init must be between 0 and 1")
+        if not (0.0 < self.residual_stream_write_init < 1.0):
+            raise ValueError("residual_stream_write_init must be between 0 and 1")
         for idx in self.mlp_only_layers:
             if not (0 <= idx < self.num_hidden_layers):
                 raise ValueError(f"mlp_only_layers index {idx} is out of range for {self.num_hidden_layers} layers")

--- a/src/modeling/layers.py
+++ b/src/modeling/layers.py
@@ -1,13 +1,272 @@
 """Decoder layer"""
+import math
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from typing import Optional, Tuple
 from src.configuration_bibo import BiBoConfig
 from .norm import BiBoRMSNorm
 from .attn import BiBoAttention
 from .ffn import BiBoMLP, BiBoMoELayer
 
-__all__ = ['BiBoDecoderLayer']
+__all__ = [
+    'BiBoResidualGate',
+    'BiBoCausalResidualConv',
+    'BiBoMultiStreamResidual',
+    'BiBoDecoderLayer',
+]
+
+
+def _logit(probability: float) -> float:
+    return math.log(probability / (1.0 - probability))
+
+
+def _stream_probs(num_streams: int, main_mass: float) -> torch.Tensor:
+    probs = torch.full((num_streams,), (1.0 - main_mass) / (num_streams - 1), dtype=torch.float32)
+    probs[0] = main_mass
+    return probs
+
+
+class BiBoResidualGate(nn.Module):
+    """
+    Optional residual write gate.
+
+    This keeps the identity path intact and only scales the branch update:
+    `x = residual + gate * branch_output`. Initializing the gate near 1.0
+    preserves baseline Transformer behavior while still letting training learn
+    token-wise or channel-wise residual flow control.
+    """
+    def __init__(self, config: BiBoConfig, branch_name: str):
+        super().__init__()
+        self.gate_type = config.residual_gate_type
+        self.hidden_size = config.hidden_size
+        self.branch_name = branch_name
+
+        if self.gate_type == "none":
+            self.weight = None
+            self.bias = None
+        elif self.gate_type == "scalar":
+            init_logit = math.log(config.residual_gate_init / (1.0 - config.residual_gate_init))
+            self.weight = None
+            self.bias = nn.Parameter(torch.full((1,), init_logit))
+        else:
+            out_features = {
+                "token": 1,
+                "channel": self.hidden_size,
+            }[self.gate_type]
+            init_logit = math.log(config.residual_gate_init / (1.0 - config.residual_gate_init))
+            # Use raw parameters instead of nn.Linear so PreTrainedModel.post_init
+            # does not overwrite the near-identity gate initialization.
+            self.weight = nn.Parameter(torch.zeros(out_features, self.hidden_size))
+            self.bias = nn.Parameter(torch.full((out_features,), init_logit))
+
+        self.register_buffer("last_gate_mean", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_gate_open_frac", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_gate_closed_frac", torch.tensor(float("nan")), persistent=False)
+
+    def forward(self, gate_input: torch.Tensor, branch_output: torch.Tensor) -> torch.Tensor:
+        if self.gate_type == "none":
+            return branch_output
+
+        if self.gate_type == "scalar":
+            logits = self.bias.view(1, 1, 1).expand(*branch_output.shape[:-1], 1)
+        else:
+            logits = F.linear(gate_input.to(self.weight.dtype), self.weight, self.bias)
+
+        gate = torch.sigmoid(logits).to(branch_output.dtype)
+        gated_output = branch_output * gate
+
+        if not torch.jit.is_scripting():
+            with torch.no_grad():
+                gate_float = gate.detach().float()
+                self.last_gate_mean.copy_(gate_float.mean())
+                self.last_gate_open_frac.copy_((gate_float > 0.9).float().mean())
+                self.last_gate_closed_frac.copy_((gate_float < 0.1).float().mean())
+
+        return gated_output
+
+    def stats(self) -> dict:
+        if self.gate_type == "none":
+            return {}
+        return {
+            f"{self.branch_name}/mean": float(self.last_gate_mean.item()),
+            f"{self.branch_name}/open_frac": float(self.last_gate_open_frac.item()),
+            f"{self.branch_name}/closed_frac": float(self.last_gate_closed_frac.item()),
+        }
+
+
+class BiBoCausalResidualConv(nn.Module):
+    """
+    Causal convolution over residual states along model depth.
+
+    This is an attention-residual-style read mixer with a fixed causal window:
+    the current layer can read only previous depth states plus its own output.
+    It does not convolve over sequence tokens, so token-level causality is
+    preserved as long as the underlying decoder layers are causal.
+    """
+    def __init__(self, config: BiBoConfig, layer_idx: int):
+        super().__init__()
+        self.mixer_type = config.residual_mixer_type
+        self.kernel_size = config.residual_conv_kernel_size
+        self.layer_idx = layer_idx
+
+        if self.mixer_type == "none":
+            self.kernel_logits = None
+            self.dynamic_weight = None
+            self.dynamic_bias = None
+        else:
+            previous_mass = 1.0 - config.residual_conv_init
+            previous_prob = previous_mass / (self.kernel_size - 1)
+            probs = torch.full((self.kernel_size,), previous_prob, dtype=torch.float32)
+            probs[-1] = config.residual_conv_init
+            if self.mixer_type == "causal_conv":
+                self.kernel_logits = nn.Parameter(torch.log(probs))
+                self.dynamic_weight = None
+                self.dynamic_bias = None
+            else:
+                self.kernel_logits = None
+                self.dynamic_weight = nn.Parameter(torch.zeros(self.kernel_size, config.hidden_size))
+                self.dynamic_bias = nn.Parameter(torch.log(probs))
+
+        self.register_buffer("last_current_weight", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_previous_mass", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_num_states", torch.tensor(0, dtype=torch.long), persistent=False)
+
+    def forward(
+        self,
+        current_state: torch.Tensor,
+        residual_history: Optional[Tuple[torch.Tensor, ...]],
+    ) -> torch.Tensor:
+        if self.mixer_type == "none":
+            return current_state
+
+        history = tuple(residual_history or ())
+        states = history[-(self.kernel_size - 1):] + (current_state,)
+        num_states = len(states)
+        if self.mixer_type == "causal_conv":
+            logits = self.kernel_logits[-num_states:]
+            weights = torch.softmax(logits.float(), dim=0).to(current_state.dtype)
+            stacked = torch.stack(states, dim=0)
+            mixed = torch.sum(stacked * weights.view(num_states, 1, 1, 1), dim=0)
+        else:
+            logits = F.linear(
+                current_state.to(self.dynamic_weight.dtype),
+                self.dynamic_weight[-num_states:],
+                self.dynamic_bias[-num_states:],
+            )
+            weights = torch.softmax(logits.float(), dim=-1).to(current_state.dtype)
+            stacked = torch.stack(states, dim=2)
+            mixed = torch.sum(stacked * weights.unsqueeze(-1), dim=2)
+
+        if not torch.jit.is_scripting():
+            with torch.no_grad():
+                weights_float = weights.detach().float()
+                self.last_current_weight.copy_(weights_float[..., -1].mean())
+                self.last_previous_mass.copy_(weights_float[..., :-1].sum(dim=-1).mean())
+                self.last_num_states.copy_(torch.tensor(num_states, device=self.last_num_states.device))
+
+        return mixed
+
+    def stats(self) -> dict:
+        if self.mixer_type == "none":
+            return {}
+        return {
+            f"layer_{self.layer_idx}/residual_conv/current_weight": float(self.last_current_weight.item()),
+            f"layer_{self.layer_idx}/residual_conv/previous_mass": float(self.last_previous_mass.item()),
+            f"layer_{self.layer_idx}/residual_conv/num_states": int(self.last_num_states.item()),
+        }
+
+
+class BiBoMultiStreamResidual(nn.Module):
+    """
+    mHC-style parallel residual streams with learned read/write gates.
+
+    The model reads a gated mixture of streams before a layer, runs the normal
+    decoder block, then writes the layer delta back into the streams. This keeps
+    attention/MoE modules unchanged while giving each layer token-wise control
+    over which residual lanes are useful.
+    """
+    def __init__(self, config: BiBoConfig, layer_idx: int):
+        super().__init__()
+        self.num_streams = config.residual_num_streams
+        self.gate_type = config.residual_stream_gate_type
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+
+        if self.num_streams <= 1:
+            self.read_weight = None
+            self.read_bias = None
+            self.write_weight = None
+            self.write_bias = None
+        else:
+            read_probs = _stream_probs(self.num_streams, config.residual_stream_read_init)
+            write_probs = _stream_probs(self.num_streams, config.residual_stream_write_init)
+            if self.gate_type == "scalar":
+                self.read_weight = None
+                self.write_weight = None
+            else:
+                self.read_weight = nn.Parameter(torch.zeros(self.num_streams, self.hidden_size))
+                self.write_weight = nn.Parameter(torch.zeros(self.num_streams, self.hidden_size))
+            self.read_bias = nn.Parameter(torch.log(read_probs))
+            self.write_bias = nn.Parameter(torch.tensor([_logit(float(p)) for p in write_probs]))
+
+        self.register_buffer("last_read_main", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_read_entropy", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_write_main", torch.tensor(float("nan")), persistent=False)
+        self.register_buffer("last_write_aux", torch.tensor(float("nan")), persistent=False)
+
+    def read(self, streams: torch.Tensor) -> torch.Tensor:
+        if self.num_streams <= 1:
+            return streams[:, :, 0, :]
+
+        controller = streams.mean(dim=2)
+        if self.gate_type == "scalar":
+            logits = self.read_bias.view(1, 1, self.num_streams)
+        else:
+            logits = F.linear(controller.to(self.read_weight.dtype), self.read_weight, self.read_bias)
+        weights = torch.softmax(logits.float(), dim=-1).to(streams.dtype)
+        mixed = torch.sum(streams * weights.unsqueeze(-1), dim=2)
+
+        if not torch.jit.is_scripting():
+            with torch.no_grad():
+                weights_float = weights.detach().float()
+                entropy = -(weights_float * torch.log(weights_float.clamp_min(1e-8))).sum(dim=-1)
+                self.last_read_main.copy_(weights_float[..., 0].mean())
+                self.last_read_entropy.copy_(entropy.mean())
+
+        return mixed
+
+    def write(self, streams: torch.Tensor, update: torch.Tensor) -> torch.Tensor:
+        if self.num_streams <= 1:
+            return streams + update.unsqueeze(2)
+
+        if self.gate_type == "scalar":
+            logits = self.write_bias.view(1, 1, self.num_streams)
+        else:
+            logits = F.linear(update.to(self.write_weight.dtype), self.write_weight, self.write_bias)
+        gates = torch.sigmoid(logits).to(update.dtype)
+        streams = streams + gates.unsqueeze(-1) * update.unsqueeze(2)
+
+        if not torch.jit.is_scripting():
+            with torch.no_grad():
+                gates_float = gates.detach().float()
+                self.last_write_main.copy_(gates_float[..., 0].mean())
+                if self.num_streams > 1:
+                    self.last_write_aux.copy_(gates_float[..., 1:].mean())
+                else:
+                    self.last_write_aux.copy_(torch.tensor(0.0, device=self.last_write_aux.device))
+
+        return streams
+
+    def stats(self) -> dict:
+        if self.num_streams <= 1:
+            return {}
+        return {
+            f"layer_{self.layer_idx}/streams/read_main": float(self.last_read_main.item()),
+            f"layer_{self.layer_idx}/streams/read_entropy": float(self.last_read_entropy.item()),
+            f"layer_{self.layer_idx}/streams/write_main": float(self.last_write_main.item()),
+            f"layer_{self.layer_idx}/streams/write_aux": float(self.last_write_aux.item()),
+        }
 
 
 class BiBoDecoderLayer(nn.Module):
@@ -43,6 +302,9 @@ class BiBoDecoderLayer(nn.Module):
 
         self.input_layernorm = BiBoRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = BiBoRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn_residual_gate = BiBoResidualGate(config, "attn")
+        self.mlp_residual_gate = BiBoResidualGate(config, "mlp")
+        self.residual_mixer = BiBoCausalResidualConv(config, layer_idx)
 
     def forward(
         self,
@@ -53,6 +315,7 @@ class BiBoDecoderLayer(nn.Module):
         cache_position: Optional[torch.LongTensor] = None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
+        residual_history: Optional[Tuple[torch.Tensor, ...]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         """
@@ -70,6 +333,7 @@ class BiBoDecoderLayer(nn.Module):
         """
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
+        gate_input = hidden_states
 
         # Self attention
         attn_output, self_attn_weights, present_key_value = self.self_attn(
@@ -81,13 +345,15 @@ class BiBoDecoderLayer(nn.Module):
             output_attentions=output_attentions,
             use_cache=use_cache,
         )
-        hidden_states = residual + attn_output
+        hidden_states = residual + self.attn_residual_gate(gate_input, attn_output)
 
         # FFN
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
+        gate_input = hidden_states
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
+        hidden_states = residual + self.mlp_residual_gate(gate_input, hidden_states)
+        hidden_states = self.residual_mixer(hidden_states, residual_history)
 
         outputs = (hidden_states,)
         if output_attentions:
@@ -96,3 +362,16 @@ class BiBoDecoderLayer(nn.Module):
             outputs += (present_key_value,)
 
         return outputs
+
+    def residual_gate_stats(self) -> dict:
+        if self.attn_residual_gate.gate_type == "none":
+            return {}
+        stats = {}
+        for name, value in self.attn_residual_gate.stats().items():
+            stats[f"layer_{self.layer_idx}/{name}"] = value
+        for name, value in self.mlp_residual_gate.stats().items():
+            stats[f"layer_{self.layer_idx}/{name}"] = value
+        return stats
+
+    def residual_mixer_stats(self) -> dict:
+        return self.residual_mixer.stats()

--- a/src/modeling/layers.py
+++ b/src/modeling/layers.py
@@ -181,14 +181,15 @@ class BiBoMultiStreamResidual(nn.Module):
     """
     mHC-style parallel residual streams with learned read/write gates.
 
-    The model reads a gated mixture of streams before a layer, runs the normal
-    decoder block, then writes the layer delta back into the streams. This keeps
-    attention/MoE modules unchanged while giving each layer token-wise control
-    over which residual lanes are useful.
+    In independent mode, the model reads a gated mixture of streams before a
+    layer, runs the normal decoder block, then writes the layer delta back into
+    the streams. In delay-line mode, stream index is a causal depth axis: stream
+    0 holds the newest layer state and writes shift older states right.
     """
     def __init__(self, config: BiBoConfig, layer_idx: int):
         super().__init__()
         self.num_streams = config.residual_num_streams
+        self.stream_mode = config.residual_stream_mode
         self.gate_type = config.residual_stream_gate_type
         self.hidden_size = config.hidden_size
         self.layer_idx = layer_idx
@@ -200,15 +201,21 @@ class BiBoMultiStreamResidual(nn.Module):
             self.write_bias = None
         else:
             read_probs = _stream_probs(self.num_streams, config.residual_stream_read_init)
-            write_probs = _stream_probs(self.num_streams, config.residual_stream_write_init)
             if self.gate_type == "scalar":
                 self.read_weight = None
-                self.write_weight = None
             else:
                 self.read_weight = nn.Parameter(torch.zeros(self.num_streams, self.hidden_size))
-                self.write_weight = nn.Parameter(torch.zeros(self.num_streams, self.hidden_size))
             self.read_bias = nn.Parameter(torch.log(read_probs))
-            self.write_bias = nn.Parameter(torch.tensor([_logit(float(p)) for p in write_probs]))
+            if self.stream_mode == "delay_line":
+                self.write_weight = None
+                self.write_bias = None
+            else:
+                write_probs = _stream_probs(self.num_streams, config.residual_stream_write_init)
+                if self.gate_type == "scalar":
+                    self.write_weight = None
+                else:
+                    self.write_weight = nn.Parameter(torch.zeros(self.num_streams, self.hidden_size))
+                self.write_bias = nn.Parameter(torch.tensor([_logit(float(p)) for p in write_probs]))
 
         self.register_buffer("last_read_main", torch.tensor(float("nan")), persistent=False)
         self.register_buffer("last_read_entropy", torch.tensor(float("nan")), persistent=False)
@@ -239,6 +246,14 @@ class BiBoMultiStreamResidual(nn.Module):
     def write(self, streams: torch.Tensor, update: torch.Tensor) -> torch.Tensor:
         if self.num_streams <= 1:
             return streams + update.unsqueeze(2)
+
+        if self.stream_mode == "delay_line":
+            shifted_streams = torch.cat([update.unsqueeze(2), streams[:, :, :-1, :]], dim=2)
+            if not torch.jit.is_scripting():
+                with torch.no_grad():
+                    self.last_write_main.fill_(1.0)
+                    self.last_write_aux.fill_(0.0)
+            return shifted_streams
 
         if self.gate_type == "scalar":
             logits = self.write_bias.view(1, 1, self.num_streams)

--- a/src/modeling/models.py
+++ b/src/modeling/models.py
@@ -152,6 +152,16 @@ class BiBoModel(BiBoPreTrainedModel):
             return None
 
         main_stream = hidden_states.unsqueeze(2)
+        if self.config.residual_stream_mode == "delay_line":
+            delay_shape = (
+                hidden_states.shape[0],
+                hidden_states.shape[1],
+                self.config.residual_num_streams - 1,
+                hidden_states.shape[2],
+            )
+            delay_streams = hidden_states.new_zeros(delay_shape)
+            return torch.cat([main_stream, delay_streams], dim=2)
+
         if self.config.residual_stream_init == "copy":
             return main_stream.expand(-1, -1, self.config.residual_num_streams, -1).clone()
 
@@ -234,7 +244,7 @@ class BiBoModel(BiBoPreTrainedModel):
         next_decoder_cache = None
         residual_history = None
         if self.config.residual_mixer_type != "none":
-            residual_history = [hidden_states]
+            residual_history = [hidden_states] if self.config.residual_history_include_input else []
             max_residual_history = self.config.residual_conv_kernel_size - 1
 
         for layer_idx, decoder_layer in enumerate(self.layers):
@@ -275,12 +285,15 @@ class BiBoModel(BiBoPreTrainedModel):
             hidden_states = layer_outputs[0]
 
             if residual_streams is not None:
-                layer_update = hidden_states - read_state
+                layer_update = (
+                    hidden_states
+                    if self.config.residual_stream_mode == "delay_line"
+                    else hidden_states - read_state
+                )
                 residual_streams = self.residual_stream_mixers[layer_idx].write(
                     residual_streams,
                     layer_update,
                 )
-                hidden_states = self.residual_stream_mixers[layer_idx].read(residual_streams)
 
             if residual_history is not None:
                 residual_history.append(hidden_states)
@@ -292,6 +305,9 @@ class BiBoModel(BiBoPreTrainedModel):
 
             if output_attentions:
                 all_self_attns += (layer_outputs[1],)
+
+        if residual_streams is not None:
+            hidden_states = self.residual_stream_mixers[-1].read(residual_streams)
 
         hidden_states = self.norm(hidden_states)
 

--- a/src/modeling/models.py
+++ b/src/modeling/models.py
@@ -20,7 +20,7 @@ from transformers.utils import logging
 from src.configuration_bibo import BiBoConfig
 from .norm import BiBoRMSNorm
 from .embed import BiBoRotaryEmbedding
-from .layers import BiBoDecoderLayer
+from .layers import BiBoDecoderLayer, BiBoMultiStreamResidual
 
 logger = logging.get_logger(__name__)
 
@@ -111,6 +111,9 @@ class BiBoModel(BiBoPreTrainedModel):
         self.layers = nn.ModuleList(
             [BiBoDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
+        self.residual_stream_mixers = nn.ModuleList(
+            [BiBoMultiStreamResidual(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
         self.norm = BiBoRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = BiBoRotaryEmbedding(
             config.hidden_size // config.num_attention_heads,
@@ -125,6 +128,41 @@ class BiBoModel(BiBoPreTrainedModel):
 
     def set_input_embeddings(self, value):
         self.embed_tokens = value
+
+    def residual_gate_stats(self) -> dict:
+        stats = {}
+        for layer in self.layers:
+            stats.update(layer.residual_gate_stats())
+        return stats
+
+    def residual_mixer_stats(self) -> dict:
+        stats = {}
+        for layer in self.layers:
+            stats.update(layer.residual_mixer_stats())
+        return stats
+
+    def residual_stream_stats(self) -> dict:
+        stats = {}
+        for mixer in self.residual_stream_mixers:
+            stats.update(mixer.stats())
+        return stats
+
+    def _init_residual_streams(self, hidden_states: torch.Tensor) -> Optional[torch.Tensor]:
+        if self.config.residual_num_streams <= 1:
+            return None
+
+        main_stream = hidden_states.unsqueeze(2)
+        if self.config.residual_stream_init == "copy":
+            return main_stream.expand(-1, -1, self.config.residual_num_streams, -1).clone()
+
+        aux_shape = (
+            hidden_states.shape[0],
+            hidden_states.shape[1],
+            self.config.residual_num_streams - 1,
+            hidden_states.shape[2],
+        )
+        aux_streams = hidden_states.new_zeros(aux_shape)
+        return torch.cat([main_stream, aux_streams], dim=2)
 
     def forward(
         self,
@@ -185,6 +223,7 @@ class BiBoModel(BiBoPreTrainedModel):
         )
 
         hidden_states = inputs_embeds
+        residual_streams = self._init_residual_streams(hidden_states)
 
         # Position embeddings
         position_embeddings = self.rotary_emb(hidden_states, cache_position)
@@ -193,10 +232,21 @@ class BiBoModel(BiBoPreTrainedModel):
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
         next_decoder_cache = None
+        residual_history = None
+        if self.config.residual_mixer_type != "none":
+            residual_history = [hidden_states]
+            max_residual_history = self.config.residual_conv_kernel_size - 1
 
-        for decoder_layer in self.layers:
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            read_state = hidden_states
+            if residual_streams is not None:
+                read_state = self.residual_stream_mixers[layer_idx].read(residual_streams)
+                hidden_states = read_state
+
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
+
+            residual_history_arg = tuple(residual_history) if residual_history is not None else None
 
             if self.gradient_checkpointing and self.training:
                 layer_outputs = self._gradient_checkpointing_func(
@@ -208,6 +258,7 @@ class BiBoModel(BiBoPreTrainedModel):
                     cache_position,
                     output_attentions,
                     False,
+                    residual_history_arg,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -218,9 +269,23 @@ class BiBoModel(BiBoPreTrainedModel):
                     cache_position=cache_position,
                     output_attentions=output_attentions,
                     use_cache=use_cache,
+                    residual_history=residual_history_arg,
                 )
 
             hidden_states = layer_outputs[0]
+
+            if residual_streams is not None:
+                layer_update = hidden_states - read_state
+                residual_streams = self.residual_stream_mixers[layer_idx].write(
+                    residual_streams,
+                    layer_update,
+                )
+                hidden_states = self.residual_stream_mixers[layer_idx].read(residual_streams)
+
+            if residual_history is not None:
+                residual_history.append(hidden_states)
+                if len(residual_history) > max_residual_history:
+                    residual_history = residual_history[-max_residual_history:]
 
             if use_cache:
                 next_decoder_cache = layer_outputs[2 if output_attentions else 1]

--- a/tests/modular/test_modular.py
+++ b/tests/modular/test_modular.py
@@ -7,6 +7,7 @@ from src.configuration_bibo import BiBoConfig
 from src.modeling.models import BiBoModel, BiBoForCausalLM
 from src.modeling.attn import BiBoAttention
 from src.modeling.ffn import BiBoMLP, BiBoMoELayer
+from src.modeling.layers import BiBoCausalResidualConv, BiBoMultiStreamResidual, BiBoResidualGate
 
 @pytest.fixture
 def cfg():
@@ -79,6 +80,229 @@ def test_forward_backward(cfg):
     has_grads = sum(1 for p in model.parameters() if p.grad is not None)
     total_params = sum(1 for _ in model.parameters())
     print(f"✓ Backward: {has_grads}/{total_params} params have grads")
+
+def test_residual_gate_starts_near_identity():
+    """Residual write gate should preserve baseline flow at init."""
+    cfg = BiBoConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_routed_experts=8,
+        residual_gate_type="token",
+        residual_gate_init=0.95,
+    )
+    gate = BiBoResidualGate(cfg, "attn")
+    x = torch.randn(2, 8, cfg.hidden_size)
+    branch = torch.ones_like(x)
+
+    out = gate(x, branch)
+    assert out.shape == branch.shape
+    assert torch.allclose(out.mean(), torch.tensor(0.95), atol=1e-5)
+    assert gate.stats()["attn/mean"] == pytest.approx(0.95, abs=1e-5)
+
+def test_residual_gates_work_in_model_and_receive_gradients():
+    """Token gates should expose per-branch flow stats and train."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_gate_type="token",
+        residual_gate_init=0.95,
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+    stats = model.model.residual_gate_stats()
+
+    assert "layer_0/attn/mean" in stats
+    assert "layer_0/mlp/mean" in stats
+    assert stats["layer_0/attn/mean"] == pytest.approx(0.95, abs=1e-5)
+    assert stats["layer_0/mlp/mean"] == pytest.approx(0.95, abs=1e-5)
+    assert model.model.layers[0].attn_residual_gate.bias.grad is not None
+    assert model.model.layers[0].mlp_residual_gate.bias.grad is not None
+
+def test_causal_residual_conv_starts_near_current_state():
+    """Depth-causal residual conv should prefer the current layer at init."""
+    cfg = BiBoConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_routed_experts=8,
+        residual_mixer_type="causal_conv",
+        residual_conv_kernel_size=3,
+        residual_conv_init=0.9,
+    )
+    mixer = BiBoCausalResidualConv(cfg, layer_idx=0)
+    current = torch.ones(2, 8, cfg.hidden_size)
+    previous = torch.zeros_like(current)
+
+    mixed = mixer(current, (previous, previous))
+    assert mixed.shape == current.shape
+    assert torch.allclose(mixed.mean(), torch.tensor(0.9), atol=1e-5)
+    stats = mixer.stats()
+    assert stats["layer_0/residual_conv/current_weight"] == pytest.approx(0.9, abs=1e-5)
+    assert stats["layer_0/residual_conv/previous_mass"] == pytest.approx(0.1, abs=1e-5)
+    assert stats["layer_0/residual_conv/num_states"] == 3
+
+def test_causal_residual_conv_works_in_model_and_receives_gradients():
+    """Model should train causal depth-conv residual mixer parameters."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_mixer_type="causal_conv",
+        residual_conv_kernel_size=3,
+        residual_conv_init=0.9,
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+    stats = model.model.residual_mixer_stats()
+
+    assert "layer_0/residual_conv/current_weight" in stats
+    assert "layer_1/residual_conv/current_weight" in stats
+    assert stats["layer_1/residual_conv/num_states"] == 3
+    assert model.model.layers[0].residual_mixer.kernel_logits.grad is not None
+    assert model.model.layers[1].residual_mixer.kernel_logits.grad is not None
+
+def test_dynamic_causal_residual_conv_works_in_model_and_receives_gradients():
+    """Dynamic depth conv should learn token-conditioned residual-depth reads."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_mixer_type="dynamic_causal_conv",
+        residual_conv_kernel_size=3,
+        residual_conv_init=0.9,
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+    stats = model.model.residual_mixer_stats()
+
+    assert stats["layer_1/residual_conv/num_states"] == 3
+    assert model.model.layers[0].residual_mixer.dynamic_weight.grad is not None
+    assert model.model.layers[0].residual_mixer.dynamic_bias.grad is not None
+
+def test_multistream_residual_prefers_main_stream_at_init():
+    """mHC-style residual streams should read/write mostly from stream 0 at init."""
+    cfg = BiBoConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_routed_experts=8,
+        residual_num_streams=3,
+        residual_stream_gate_type="token",
+        residual_stream_read_init=0.9,
+        residual_stream_write_init=0.8,
+    )
+    mixer = BiBoMultiStreamResidual(cfg, layer_idx=0)
+    streams = torch.stack([
+        torch.ones(2, 8, cfg.hidden_size),
+        torch.zeros(2, 8, cfg.hidden_size),
+        torch.zeros(2, 8, cfg.hidden_size),
+    ], dim=2)
+    update = torch.ones(2, 8, cfg.hidden_size)
+
+    read = mixer.read(streams)
+    streams = mixer.write(streams, update)
+    stats = mixer.stats()
+
+    assert read.shape == (2, 8, cfg.hidden_size)
+    assert torch.allclose(read.mean(), torch.tensor(0.9), atol=1e-5)
+    assert stats["layer_0/streams/read_main"] == pytest.approx(0.9, abs=1e-5)
+    assert stats["layer_0/streams/write_main"] == pytest.approx(0.8, abs=1e-5)
+
+def test_multistream_residual_works_in_model_and_receives_gradients():
+    """Full model should train stream read/write gate parameters."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_num_streams=2,
+        residual_stream_gate_type="token",
+        residual_stream_read_init=0.99,
+        residual_stream_write_init=0.99,
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+    stats = model.model.residual_stream_stats()
+
+    assert "layer_0/streams/read_main" in stats
+    assert "layer_1/streams/write_main" in stats
+    assert model.model.residual_stream_mixers[0].read_bias.grad is not None
+    assert model.model.residual_stream_mixers[0].write_bias.grad is not None
+    assert model.model.residual_stream_mixers[0].read_weight.grad is not None
+    assert model.model.residual_stream_mixers[0].write_weight.grad is not None
+
+def test_residual_experiments_can_be_combined():
+    """Write gates, stream gates, and dynamic depth conv should compose."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_gate_type="token",
+        residual_mixer_type="dynamic_causal_conv",
+        residual_conv_kernel_size=3,
+        residual_num_streams=2,
+        residual_stream_gate_type="token",
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+
+    assert torch.isfinite(out.loss)
+    assert model.model.residual_gate_stats()
+    assert model.model.residual_mixer_stats()
+    assert model.model.residual_stream_stats()
 
 def count_params(model):
     """Count model params"""

--- a/tests/modular/test_modular.py
+++ b/tests/modular/test_modular.py
@@ -51,8 +51,8 @@ def test_model(cfg):
     model = BiBoModel(cfg)
     input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
     out = model(input_ids)
+    assert out.last_hidden_state.shape == (2, 8, cfg.hidden_size)
     print(f"✓ Model: input {input_ids.shape} → hidden {out.last_hidden_state.shape}")
-    return model
 
 def test_causal_lm(cfg):
     """Test causal LM"""
@@ -179,7 +179,9 @@ def test_causal_residual_conv_works_in_model_and_receives_gradients():
 
     assert "layer_0/residual_conv/current_weight" in stats
     assert "layer_1/residual_conv/current_weight" in stats
-    assert stats["layer_1/residual_conv/num_states"] == 3
+    assert stats["layer_0/residual_conv/num_states"] == 1
+    assert stats["layer_1/residual_conv/num_states"] == 2
+    assert stats["layer_2/residual_conv/num_states"] == 3
     assert model.model.layers[0].residual_mixer.kernel_logits.grad is not None
     assert model.model.layers[1].residual_mixer.kernel_logits.grad is not None
 
@@ -208,9 +210,44 @@ def test_dynamic_causal_residual_conv_works_in_model_and_receives_gradients():
     out.loss.backward()
     stats = model.model.residual_mixer_stats()
 
-    assert stats["layer_1/residual_conv/num_states"] == 3
+    assert stats["layer_0/residual_conv/num_states"] == 1
+    assert stats["layer_1/residual_conv/num_states"] == 2
+    assert stats["layer_2/residual_conv/num_states"] == 3
     assert model.model.layers[0].residual_mixer.dynamic_weight.grad is not None
     assert model.model.layers[0].residual_mixer.dynamic_bias.grad is not None
+
+def test_residual_history_can_include_input_when_requested():
+    """Depth residual history should exclude embeddings by default but keep the option."""
+    base_kwargs = dict(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_mixer_type="causal_conv",
+        residual_conv_kernel_size=3,
+    )
+    input_ids = torch.randint(0, 100, (2, 8))
+
+    default_model = BiBoForCausalLM(BiBoConfig(**base_kwargs))
+    default_model(input_ids)
+    default_stats = default_model.model.residual_mixer_stats()
+
+    include_input_model = BiBoForCausalLM(
+        BiBoConfig(**base_kwargs, residual_history_include_input=True)
+    )
+    include_input_model(input_ids)
+    include_input_stats = include_input_model.model.residual_mixer_stats()
+
+    assert default_stats["layer_0/residual_conv/num_states"] == 1
+    assert default_stats["layer_1/residual_conv/num_states"] == 2
+    assert include_input_stats["layer_0/residual_conv/num_states"] == 2
+    assert include_input_stats["layer_1/residual_conv/num_states"] == 3
 
 def test_multistream_residual_prefers_main_stream_at_init():
     """mHC-style residual streams should read/write mostly from stream 0 at init."""
@@ -273,6 +310,105 @@ def test_multistream_residual_works_in_model_and_receives_gradients():
     assert model.model.residual_stream_mixers[0].read_weight.grad is not None
     assert model.model.residual_stream_mixers[0].write_weight.grad is not None
 
+def test_multistream_model_reads_once_per_layer_plus_final_read():
+    """Stream reads should not repeat after every write; only final output is re-read."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_num_streams=2,
+        residual_stream_gate_type="scalar",
+    )
+    model = BiBoForCausalLM(cfg)
+
+    for mixer in model.model.residual_stream_mixers:
+        mixer._test_read_calls = 0
+        original_read = mixer.read
+
+        def counted_read(streams, *, _mixer=mixer, _original_read=original_read):
+            _mixer._test_read_calls += 1
+            return _original_read(streams)
+
+        mixer.read = counted_read
+
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    model(input_ids)
+
+    assert [mixer._test_read_calls for mixer in model.model.residual_stream_mixers] == [1, 2]
+
+def test_delay_line_residual_shifts_states_and_reads_depth_axis():
+    """Delay-line streams should encode current, one-layer-old, two-layer-old states."""
+    cfg = BiBoConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_routed_experts=8,
+        residual_num_streams=3,
+        residual_stream_mode="delay_line",
+        residual_stream_gate_type="scalar",
+        residual_stream_read_init=0.8,
+    )
+    mixer = BiBoMultiStreamResidual(cfg, layer_idx=0)
+    streams = torch.stack([
+        torch.ones(2, 8, cfg.hidden_size),
+        torch.full((2, 8, cfg.hidden_size), 2.0),
+        torch.full((2, 8, cfg.hidden_size), 3.0),
+    ], dim=2)
+    new_state = torch.full((2, 8, cfg.hidden_size), 10.0)
+
+    read = mixer.read(streams)
+    shifted = mixer.write(streams, new_state)
+    stats = mixer.stats()
+
+    assert read.shape == (2, 8, cfg.hidden_size)
+    assert read.mean().item() == pytest.approx(1.3, abs=1e-5)
+    assert torch.allclose(shifted[:, :, 0, :], new_state)
+    assert torch.allclose(shifted[:, :, 1, :], streams[:, :, 0, :])
+    assert torch.allclose(shifted[:, :, 2, :], streams[:, :, 1, :])
+    assert mixer.write_bias is None
+    assert stats["layer_0/streams/read_main"] == pytest.approx(0.8, abs=1e-5)
+    assert stats["layer_0/streams/write_main"] == pytest.approx(1.0, abs=1e-5)
+
+def test_delay_line_residual_works_in_model_and_receives_gradients():
+    """Delay-line mode should train only the causal depth read gates."""
+    cfg = BiBoConfig(
+        vocab_size=100,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        use_sliding_window=False,
+        residual_num_streams=3,
+        residual_stream_mode="delay_line",
+        residual_stream_gate_type="token",
+        residual_stream_read_init=0.9,
+    )
+    model = BiBoForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (2, 8))
+    labels = torch.randint(0, cfg.vocab_size, (2, 8))
+
+    out = model(input_ids, labels=labels)
+    out.loss.backward()
+    stats = model.model.residual_stream_stats()
+
+    assert torch.isfinite(out.loss)
+    assert "layer_0/streams/read_main" in stats
+    assert stats["layer_0/streams/write_main"] == pytest.approx(1.0, abs=1e-5)
+    assert model.model.residual_stream_mixers[0].read_bias.grad is not None
+    assert model.model.residual_stream_mixers[0].read_weight.grad is not None
+    assert model.model.residual_stream_mixers[0].write_bias is None
+    assert model.model.residual_stream_mixers[0].write_weight is None
+
 def test_residual_experiments_can_be_combined():
     """Write gates, stream gates, and dynamic depth conv should compose."""
     cfg = BiBoConfig(
@@ -321,7 +457,8 @@ if __name__ == "__main__":
     test_moe(cfg)
     print()
     
-    model = test_model(cfg)
+    test_model(cfg)
+    model = BiBoModel(cfg)
     count_params(model)
     print()
     


### PR DESCRIPTION
Add configurable residual routing experiments

Implemented a set of optional residual-flow mechanisms inspired by mHC and
attention residuals. All new paths are config-gated and default to baseline
Transformer behavior when disabled.

Changes:
- Added residual write gates around attention and MLP/MoE branch outputs.
  - New config:
    - residual_gate_type: none | scalar | token | channel
    - residual_gate_init
  - Applies:
    - hidden_states = residual + gate * branch_output
  - Keeps the identity residual path intact.
  - Supports per-layer scalar gates, per-token gates, and per-token/channel gates.
  - Initializes gates near 1.0 to preserve baseline behavior.

- Added causal residual-depth convolution.
  - New config:
    - residual_mixer_type: none | causal_conv | dynamic_causal_conv
    - residual_conv_kernel_size
    - residual_conv_init
  - Mixes previous residual states plus the current layer output over model depth.
  - Fully causal over depth: a layer only sees earlier layer states and its own output.
  - Does not convolve over sequence tokens, so token-level causality is preserved.
  - causal_conv uses a learned static depth kernel per layer.
  - dynamic_causal_conv uses token-conditioned depth kernels from the current state.
  - Initializes with most mass on the current layer output to stay close to normal residual flow.

- Added mHC-style parallel residual streams.
  - New config:
    - residual_num_streams
    - residual_stream_gate_type: scalar | token
    - residual_stream_init: copy | zero
    - residual_stream_read_init
    - residual_stream_write_init
  - residual_num_streams=1 disables the feature.
  - Each layer reads a gated mixture of residual streams, runs the normal decoder
    block, then writes the layer update back into the streams with learned gates.
  - Supports scalar stream gates or per-token stream gates.
  - Keeps attention and MoE internals unchanged.

- Added residual-flow diagnostics.
  - model.model.residual_gate_stats()
  - model.model.residual_mixer_stats()
  - model.model.residual_stream_stats()
  - Tracks gate means, open/closed fractions, residual depth current/previous
    mass, and stream read/write behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added residual write gates, depth-wise residual mixing, and multi-stream residual controls; public config options and runtime stats expose these behaviors.

* **Documentation**
  * README and configuration guide updated with examples, parameter descriptions, formulas, and inspection calls for residual gates/mixers/streams.

* **Tests**
  * Added extensive unit/integration tests covering gating, causal mixing, history inclusion, multistream behavior, and combined workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->